### PR TITLE
Update DashboardModel.php

### DIFF
--- a/src/Dashboard/DashboardModel.php
+++ b/src/Dashboard/DashboardModel.php
@@ -100,7 +100,7 @@ class DashboardModel extends DashboardDashboardsEntryModel implements DashboardI
      */
     public function getWidgets()
     {
-        return $this->widgets;
+        return $this->widgets->allowed();
     }
 
     /**


### PR DESCRIPTION
The roles list in widgets is currently useless as all widgets are always returned.  This change returns only the allowed widgets allowing you to target widgets at specific user roles as intended.